### PR TITLE
Add image compression for avatar uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@supabase/supabase-js": "^2.50.3",
         "@unhead/vue": "^2.0.12",
         "better-sqlite3": "^12.2.0",
+        "browser-image-compression": "^2.0.2",
         "eslint": "^9.30.1",
         "nuxt": "^3.17.6",
         "pinia": "^3.0.3",
@@ -6018,6 +6019,15 @@
       "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
       "dependencies": {
         "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
       }
     },
     "node_modules/browserslist": {
@@ -15963,6 +15973,12 @@
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
+      "license": "MIT"
     },
     "node_modules/valibot": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@supabase/supabase-js": "^2.50.3",
     "@unhead/vue": "^2.0.12",
     "better-sqlite3": "^12.2.0",
+    "browser-image-compression": "^2.0.2",
     "eslint": "^9.30.1",
     "nuxt": "^3.17.6",
     "pinia": "^3.0.3",


### PR DESCRIPTION
Introduce image compression for avatar uploads to optimize file size and update the profile edit functionality to ensure old avatars are removed before uploading new ones. This change improves user experience by preventing cache issues with avatar images.