### PR TITLE
Mock fetch functions and add unit tests for follow count components

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -42,7 +42,6 @@
     - [ ] modals
     - [ ] ask form
     - [ ] edit profile form
-    - [ ] follow count
     - [ ] loading/error component
     - [ ] logout
 

--- a/tests/unit/components/FollowerCount.spec.ts
+++ b/tests/unit/components/FollowerCount.spec.ts
@@ -18,7 +18,7 @@ describe("FollowerCount", () => {
 	});
 
 	it("shows 1 follower if user has one follower", async () => {
-		fetchFollowerCount.mockResolvedValueOnce(1);
+		vi.mocked(fetchFollowerCount).mockResolvedValueOnce(1);
 		const component = mount(FollowerCount, {
 			props: { userId: "1" },
 		});

--- a/tests/unit/components/FollowerCount.spec.ts
+++ b/tests/unit/components/FollowerCount.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import FollowerCount from "@/components/FollowerCount.vue";
+import { fetchFollowerCount } from "@/composables/useFollow";
+
+describe("FollowerCount", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("renders follower count", async () => {
+		const component = mount(FollowerCount, {
+			props: { userId: "1" },
+		});
+		await component.vm.$nextTick();
+		await flushPromises();
+		expect(component.text()).toContain("42 Followers");
+	});
+
+	it("shows 1 follower if user has one follower", async () => {
+		fetchFollowerCount.mockResolvedValueOnce(1);
+		const component = mount(FollowerCount, {
+			props: { userId: "1" },
+		});
+		await component.vm.$nextTick();
+		await flushPromises();
+		expect(component.text()).toContain("1 Follower");
+	});
+
+	it("shows 0 followers if no userId", async () => {
+		const component = mount(FollowerCount, {
+			props: { userId: "" },
+		});
+		await component.vm.$nextTick();
+		await flushPromises();
+		expect(component.text()).toContain("0 Followers");
+	});
+});

--- a/tests/unit/components/FollowingCount.spec.ts
+++ b/tests/unit/components/FollowingCount.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import FollowingCount from "@/components/FollowingCount.vue";
+
+describe("FollowingCount", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("renders following count", async () => {
+		const component = mount(FollowingCount, {
+			props: { userId: "1" },
+		});
+		await component.vm.$nextTick();
+		await flushPromises();
+		expect(component.text()).toContain("17 Following");
+	});
+
+	it("shows 0 following if no userId", async () => {
+		const component = mount(FollowingCount, {
+			props: { userId: "" },
+		});
+		await component.vm.$nextTick();
+		await flushPromises();
+		expect(component.text()).toContain("0 Following");
+	});
+});

--- a/tests/unit/vitest.setup.ts
+++ b/tests/unit/vitest.setup.ts
@@ -54,6 +54,11 @@ vi.mock("#imports", () => {
 	};
 });
 
+vi.mock("@/composables/useFollow", () => ({
+	fetchFollowingCount: vi.fn().mockResolvedValue(17),
+	fetchFollowerCount: vi.fn().mockResolvedValue(42),
+}));
+
 config.global.stubs = {
 	NuxtLink: {
 		template: '<a :href="to"><slot /></a>',


### PR DESCRIPTION
- Mock fetch functions for follower and following counts in the useFollow composable.
- Add unit tests for the FollowingCount and FollowerCount components to ensure correct rendering and behavior.
- Remove follow count from the unit tests TODO checklist.